### PR TITLE
Allow sending bigstring continuations from server to client

### DIFF
--- a/examples/lwt/echo_server.ml
+++ b/examples/lwt/echo_server.ml
@@ -8,14 +8,16 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
   let websocket_handler _ wsd =
     let frame ~opcode ~is_fin:_ bs ~off ~len =
       match opcode with
-      | `Continuation
-      | `Text
       | `Binary ->
+        Websocketaf.Wsd.schedule wsd bs ~kind:`Binary ~off ~len
+      | `Continuation ->
+        Websocketaf.Wsd.schedule wsd bs ~kind:`Continuation ~off ~len
+      | `Text ->
         Websocketaf.Wsd.schedule wsd bs ~kind:`Text ~off ~len
       | `Connection_close ->
         Websocketaf.Wsd.close wsd
       | `Ping ->
-        Websocketaf.Wsd.send_ping wsd
+        Websocketaf.Wsd.send_pong wsd
       | `Pong
       | `Other _ ->
         ()

--- a/examples/lwt/echo_server_upgrade.ml
+++ b/examples/lwt/echo_server_upgrade.ml
@@ -10,14 +10,16 @@ let connection_handler =
   let websocket_handler _client_address wsd =
     let frame ~opcode ~is_fin:_ bs ~off ~len =
       match opcode with
-      | `Continuation
-      | `Text
       | `Binary ->
+        Websocketaf.Wsd.schedule wsd bs ~kind:`Binary ~off ~len
+      | `Continuation ->
+        Websocketaf.Wsd.schedule wsd bs ~kind:`Continuation ~off ~len
+      | `Text ->
         Websocketaf.Wsd.schedule wsd bs ~kind:`Text ~off ~len
       | `Connection_close ->
         Websocketaf.Wsd.close wsd
       | `Ping ->
-        Websocketaf.Wsd.send_ping wsd
+        Websocketaf.Wsd.send_pong wsd
       | `Pong
       | `Other _ ->
         ()

--- a/lib/websocketaf.mli
+++ b/lib/websocketaf.mli
@@ -14,7 +14,7 @@ module Wsd : sig
 
   val schedule
     :  t
-    -> kind:[ `Text | `Binary ]
+    -> kind:[ `Text | `Binary | `Continuation ]
     -> Bigstringaf.t
     -> off:int
     -> len:int
@@ -22,7 +22,7 @@ module Wsd : sig
 
   val send_bytes
     :  t
-    -> kind:[ `Text | `Binary ]
+    -> kind:[ `Text | `Binary | `Continuation ]
     -> Bytes.t
     -> off:int
     -> len:int


### PR DESCRIPTION
This allows the echo examples to respond with the exact kinds of data they were sent.