### PR TITLE
Fix issue with  determining if frame has a Fin code and fix name in async opam file

### DIFF
--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -146,7 +146,7 @@ module Frame = struct
 
   let is_fin t =
     let bits = Bigstringaf.unsafe_get t 0 |> Char.code in
-    bits land (1 lsl 8) = 1 lsl 8
+    (7 lsr bits) land 1 = 1
   ;;
 
   let rsv t =

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -146,7 +146,7 @@ module Frame = struct
 
   let is_fin t =
     let bits = Bigstringaf.unsafe_get t 0 |> Char.code in
-    (7 lsr bits) land 1 = 1
+    bits land (1 lsl 7) = 1 lsl 7
   ;;
 
   let rsv t =

--- a/websocketaf-async.opam
+++ b/websocketaf-async.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "websocketaf-lwt"
+name: "websocketaf-async"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Antonio N. Monteiro <anmonteiro@gmail.com>" ]
 license: "BSD-3-clause"
@@ -19,4 +19,4 @@ depends: [
   "digestif"
   "base64"
 ]
-synopsis: "Lwt support for websocket/af"
+synopsis: "async support for websocket/af"


### PR DESCRIPTION
This pull request fixes a bug where the lib fails checking if a frame has a Fin code. You can confirm the bug by connecting a web socket in a browser and sending a message. In the ws handler the is_fin param will be false even though the default behavior for the browser is to always set Fin code when sending data. Also Corrects the name of the async package in websocketaf-async.opam file

```HTML
<!DOCTYPE HTML>

<html>
   <head>

      <script type = "text/javascript">
         function WebSocketTest() {

            if ("WebSocket" in window) {
               alert("WebSocket is supported by your Browser!");

               // Let us open a web socket
               var ws = new WebSocket("ws://localhost:8000/ws");

               ws.onopen = function() {

                  // Web Socket is connected, send data using send()
                  ws.send("Message to send");
                  alert("Message is sent...");

               };

               ws.onmessage = function (evt) {
                  var received_msg = evt.data;
                  alert("Message is received");
                  alert(received_msg)
                //   ws.close(1000, "nothign personal")
               };

               ws.onclose = function() {
                  console.log('sdfsdfs')
                  // websocket is closed.
                  alert("Connection is closed...");
               };
            } else {

               // The browser doesn't support WebSocket
               alert("WebSocket NOT supported by your Browser!");
            }
         }
      </script>

   </head>

   <body>
      <div id = "sse">
         <a href = "javascript:WebSocketTest()">Run WebSocket</a>
      </div>

   </body>
</html>
```