### PR TITLE
Reader: read multiple frames from the buffer

### DIFF
--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -13,12 +13,12 @@ type 'error t =
 let create frame_handler =
   let parser =
     let open Angstrom in
-    Websocket.Frame.parse
-    >>| fun frame ->
-      let is_fin = Websocket.Frame.is_fin frame in
-      let opcode = Websocket.Frame.opcode frame in
-      Websocket.Frame.unmask_inplace frame;
-      Websocket.Frame.with_payload frame ~f:(frame_handler ~opcode ~is_fin)
+    skip_many
+      (Websocket.Frame.parse <* commit >>| fun frame ->
+        let is_fin = Websocket.Frame.is_fin frame in
+        let opcode = Websocket.Frame.opcode frame in
+        Websocket.Frame.unmask_inplace frame;
+        Websocket.Frame.with_payload frame ~f:(frame_handler ~opcode ~is_fin))
   in
   { parser
   ; parse_state = Done

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -322,13 +322,4 @@ module Frame = struct
     end;
     Faraday.write_bytes faraday payload ~off ~len;
   ;;
-
-  let schedule_serialize_bytes ?mask faraday ~is_fin ~opcode ~payload ~off ~len =
-    serialize_headers faraday ?mask ~is_fin ~opcode ~payload_length:len;
-    begin match mask with
-    | None -> ()
-    | Some mask -> apply_mask_bytes mask payload ~off ~len
-    end;
-    Faraday.write_bytes faraday payload ~off ~len;
-  ;;
 end

--- a/lib/websocketaf.mli
+++ b/lib/websocketaf.mli
@@ -246,16 +246,6 @@ module Websocket : sig
       -> len:int
       -> unit
 
-    val schedule_serialize_bytes
-      :  ?mask:int32
-      -> Faraday.t
-      -> is_fin:bool
-      -> opcode:Opcode.t
-      -> payload:Bytes.t
-      -> off:int
-      -> len:int
-      -> unit
-
     val serialize_bytes
       :  ?mask:int32
       -> Faraday.t

--- a/lib/wsd.ml
+++ b/lib/wsd.ml
@@ -46,7 +46,7 @@ let schedule t ~kind payload ~off ~len =
 
 let send_bytes t ~kind payload ~off ~len =
   let mask = mask t in
-  Websocket.Frame.schedule_serialize_bytes t.faraday ?mask ~is_fin:true ~opcode:(kind :> Websocket.Opcode.t) ~payload ~off ~len;
+  Websocket.Frame.serialize_bytes t.faraday ?mask ~is_fin:true ~opcode:(kind :> Websocket.Opcode.t) ~payload ~off ~len;
   wakeup t
 
 let send_ping t =

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/99aecac0.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/2af9b1f3.tar.gz;
 
 in
 


### PR DESCRIPTION
Fixes a bug where multiple frames would arrive at the same time but the
reader would only read one at a time, causing it to fall behind reading
until there was an EOF.

fixes #20