### PR TITLE
fix: mask payload correctly when sending

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -54,8 +54,6 @@ let mask_exn t =
   failwith "Frame.mask_exn: no mask present"
 ;;
 
-let payload t = t.payload
-
 let length t =
   let payload_length = payload_length t in
   Bigstringaf.length t.headers + payload_length
@@ -158,7 +156,7 @@ module Reader = struct
       let buf = Bigstringaf.create 0x1000 in
       skip_many
         (frame ~buf <* commit >>= fun frame ->
-          let payload = payload frame in
+          let payload = frame.payload in
           let is_fin = is_fin frame in
           let opcode = opcode frame in
           let len = payload_length frame in

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -145,7 +145,7 @@ module Close_code = struct
 end
 
 module Frame = struct
-  let apply_mask mask ?(off=0) ?(src_off=off) ?len bs =
+  let apply_mask mask ?(off=0) ~src_off ?len bs =
     let len =
       match len with
       | None -> Bigstringaf.length bs

--- a/lib_test/test_websocketaf.ml
+++ b/lib_test/test_websocketaf.ml
@@ -50,7 +50,7 @@ module Websocket = struct
 
     let read_payload frame =
       let rev_payload_chunks = ref [] in
-      let payload = Parse.payload frame in
+      let payload =  frame.Parse.payload in
       Payload.schedule_read payload
         ~on_eof:ignore
         ~on_read:(fun bs ~off ~len ->


### PR DESCRIPTION
we always send payloads in one go, so we don't need to keep track of bytes sent for masking