### PR TITLE
chore: upgrade dune version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.1)
+(lang dune 3.0)
 
 (name websocketaf)

--- a/examples/lwt/wscat_upgrade.ml
+++ b/examples/lwt/wscat_upgrade.ml
@@ -31,11 +31,6 @@ let websocket_handler u wsd =
   ; eof
   }
 
-let error_handler = function
-  | `Handshake_failure (rsp, _body) ->
-    Format.eprintf "Handshake failure: %a\n%!" Httpaf.Response.pp_hum rsp
-  | _ -> assert false
-
 let () =
   let host = ref None in
   let port = ref 80 in

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,11 +1,3 @@
-(executable
+(test
  (libraries websocketaf alcotest)
  (name test_websocketaf))
-
-(alias
- (name runtest)
- (package websocketaf)
- (deps
-  (:test test_websocketaf.exe))
- (action
-  (run %{test})))


### PR DESCRIPTION
This gets us `dune build @all` by default instead of `dune build @install`