### PR TITLE
feat: allow sending continuation frames

### DIFF
--- a/lib/websocketaf.mli
+++ b/lib/websocketaf.mli
@@ -88,19 +88,25 @@ module Wsd : sig
 
   val schedule
     :  t
+    -> ?is_fin:bool
     -> kind:[ `Text | `Binary | `Continuation ]
     -> Bigstringaf.t
     -> off:int
     -> len:int
     -> unit
+  (** [is_fin] defaults to [true]. Set to `false` if sending multiple frames,
+      except on the last one. *)
 
   val send_bytes
     :  t
+    -> ?is_fin:bool
     -> kind:[ `Text | `Binary | `Continuation ]
     -> Bytes.t
     -> off:int
     -> len:int
     -> unit
+  (** [is_fin] defaults to [true]. Set to `false` if sending multiple frames,
+      except on the last one. *)
 
   val send_ping : ?application_data:Bigstringaf.t IOVec.t -> t -> unit
   val send_pong : ?application_data:Bigstringaf.t IOVec.t -> t -> unit

--- a/lib/wsd.ml
+++ b/lib/wsd.ml
@@ -46,24 +46,24 @@ let wakeup t =
   t.wakeup <- Optional_thunk.none;
   Optional_thunk.call_if_some f
 
-let schedule t ~kind payload ~off ~len =
+let schedule t ?(is_fin=true) ~kind payload ~off ~len =
   let mask = mask t in
   Serialize.schedule_serialize
     t.faraday
     (* TODO: is_fin *)
     ?mask
-    ~is_fin:true
+    ~is_fin
     ~opcode:(kind :> Websocket.Opcode.t)
     ~src_off:0
     ~payload ~off ~len;
   wakeup t
 
-let send_bytes t ~kind payload ~off ~len =
+let send_bytes t ?(is_fin=true) ~kind payload ~off ~len =
   let mask = mask t in
   Serialize.serialize_bytes
     t.faraday
     ?mask
-    ~is_fin:true
+    ~is_fin
     ~opcode:(kind :> Websocket.Opcode.t)
     ~payload
     ~src_off:0


### PR DESCRIPTION
- Continuation frames only make sense when the previous frame didn't set the FIN bit
- this change allows configuring whether the FIN bit should be set (set to `true` by default)
- 