### PR TITLE
fix: always send mask from the client in ping/pong

### DIFF
--- a/lib/wsd.ml
+++ b/lib/wsd.ml
@@ -72,10 +72,10 @@ let send_bytes t ?(is_fin=true) ~kind payload ~off ~len =
   wakeup t
 
 let send_ping ?application_data t =
+  let mask = mask t in
   begin match application_data with
-  | None -> Serialize.serialize_control t.faraday ~opcode:`Ping
+  | None -> Serialize.serialize_control ?mask t.faraday ~opcode:`Ping
   | Some { IOVec.buffer; off; len } ->
-    let mask = mask t in
     Serialize.schedule_serialize
       t.faraday
       ?mask
@@ -89,10 +89,10 @@ let send_ping ?application_data t =
   wakeup t
 
 let send_pong ?application_data t =
+  let mask = mask t in
   begin match application_data with
-  | None -> Serialize.serialize_control t.faraday ~opcode:`Pong;
+  | None -> Serialize.serialize_control ?mask t.faraday ~opcode:`Pong;
   | Some { IOVec.buffer; off; len } ->
-    let mask = mask t in
     Serialize.schedule_serialize
       t.faraday
       ?mask


### PR DESCRIPTION
Currently ping/pong frames from the client have no mask if no application data is set.

> Mask:  1 bit
> 
> Defines whether the "Payload data" is masked.  If set to 1, a
> masking key is present in masking-key, and this is used to unmask
> the "Payload data" as per [Section 5.3](https://datatracker.ietf.org/doc/html/rfc6455#section-5.3).
> **All frames sent from client to server have this bit set to 1.**

For example [gorilla/websocket](https://github.com/gorilla/websocket) will reject these pings with an error `bad MASK`.