### PR TITLE
fix: mask all client frames

### DIFF
--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -1,13 +1,25 @@
-let serialize_headers ?mask faraday ~is_fin ~opcode ~payload_length =
+type mode =
+  [ `Client of unit -> int32
+  | `Server
+  ]
+
+let mask mode =
+  match mode with
+  | `Client m -> Some (m ())
+  | `Server -> None
+
+
+let serialize_headers ~mode faraday ~is_fin ~opcode ~payload_length =
   let opcode = Websocket.Opcode.to_int opcode in
   let is_fin = if is_fin then 1 lsl 7 else 0 in
+  let mask = mask mode in
   let is_mask =
     match mask with
     | None   -> 0
     | Some _ -> 1 lsl 7
   in
   Faraday.write_uint8 faraday (is_fin lor opcode);
-  if      payload_length <= 125    then
+  if payload_length <= 125    then
     Faraday.write_uint8 faraday (is_mask lor payload_length)
   else if payload_length <= 0xffff then begin
     Faraday.write_uint8     faraday (is_mask lor 126);
@@ -16,28 +28,27 @@ let serialize_headers ?mask faraday ~is_fin ~opcode ~payload_length =
     Faraday.write_uint8     faraday (is_mask lor 127);
     Faraday.BE.write_uint64 faraday (Int64.of_int payload_length);
   end;
-  begin match mask with
-  | None      -> ()
-  | Some mask -> Faraday.BE.write_uint32 faraday mask
-  end
+  Option.iter (Faraday.BE.write_uint32 faraday) mask;
+  mask
 ;;
 
-let serialize_control ?mask faraday ~opcode =
+let serialize_control ~mode faraday ~opcode =
   let opcode = (opcode :> Websocket.Opcode.t) in
-  serialize_headers faraday ?mask ~is_fin:true ~opcode ~payload_length:0
+  let _mask: int32 option =
+    serialize_headers faraday ~mode ~is_fin:true ~opcode ~payload_length:0
+  in
+  ()
 
-let schedule_serialize ?mask faraday ~is_fin ~opcode ~payload ~src_off ~off ~len =
-  serialize_headers faraday ?mask ~is_fin ~opcode ~payload_length:len;
-  begin match mask with
+let schedule_serialize ~mode faraday ~is_fin ~opcode ~payload ~src_off ~off ~len =
+  begin match serialize_headers faraday ~mode ~is_fin ~opcode ~payload_length:len with
   | None -> ()
   | Some mask -> Websocket.Frame.apply_mask mask payload ~src_off ~off ~len
   end;
   Faraday.schedule_bigstring faraday payload ~off ~len;
 ;;
 
-let serialize_bytes ?mask faraday ~is_fin ~opcode ~payload ~src_off ~off ~len =
-  serialize_headers faraday ?mask ~is_fin ~opcode ~payload_length:len;
-  begin match mask with
+let serialize_bytes ~mode faraday ~is_fin ~opcode ~payload ~src_off ~off ~len =
+  begin match serialize_headers faraday ~mode ~is_fin ~opcode ~payload_length:len with
   | None -> ()
   | Some mask -> Websocket.Frame.apply_mask_bytes mask payload ~src_off ~off ~len
   end;

--- a/lib_test/test_httpun_ws.ml
+++ b/lib_test/test_httpun_ws.ml
@@ -25,6 +25,7 @@ module Websocket = struct
       let f = Faraday.create 0x100 in
       Serialize.serialize_bytes
         f
+        ~mode:`Server
         ~is_fin
         ~opcode:`Text
         ~payload:(Bytes.of_string frame)


### PR DESCRIPTION
this is an alternative fix for #64, by moving the masking entirely to the serializer rather than requiring the `Wsd` module to pass a `?mask` argument