### PR TITLE
feat: yield the reader if reads not scheduled

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -121,7 +121,7 @@ let next_read_operation t =
         (* TODO(anmonteiro): handle this *)
         assert false
         (* set_error_and_handle t (`Exn (Failure message)); `Close *)
-    | (`Read | `Close) as operation -> operation
+    | (`Read | `Yield | `Close) as operation -> operation
 
 let read t bs ~off ~len =
   match t.state with
@@ -152,7 +152,7 @@ let report_exn t exn =
 let yield_reader t f =
   match t.state with
   | Handshake handshake -> Client_handshake.yield_reader handshake f
-  | Websocket _websocket -> assert false
+  | Websocket websocket -> Websocket_connection.yield_reader websocket f
 
 let yield_writer t f =
   match t.state with

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -218,20 +218,37 @@ module Reader = struct
         t.parse_state <- Partial continue
       | _ -> assert false
 
-  let rec read_with_more t bs ~off ~len more =
+  let rec _read_with_more t bs ~off ~len more =
+    let initial = match t.parse_state with Done -> true | _ -> false in
     let consumed =
       match t.parse_state with
       | Fail _ -> 0
+      (* Don't feed empty input when we're at a request boundary *)
+      | Done when len = 0 -> 0
       | Done   ->
         start t (AU.parse t.parser);
-        read_with_more  t bs ~off ~len more;
+        _read_with_more  t bs ~off ~len more;
       | Partial continue ->
         transition t (continue bs more ~off ~len)
     in
-    begin match more with
-    | Complete -> t.closed <- true;
-    | Incomplete -> ()
-    end;
+    (* Special case where the parser just started and was fed a zero-length
+     * bigstring. Avoid putting them parser in an error state in this scenario.
+     * If we were already in a `Partial` state, return the error. *)
+    if initial && len = 0 then t.parse_state <- Done;
+    match t.parse_state with
+    | Done when consumed < len ->
+      let off = off + consumed
+      and len = len - consumed in
+      consumed + _read_with_more t bs ~off ~len more
+    | _ -> consumed
+  ;;
+
+  let read_with_more t bs ~off ~len more =
+    let consumed = _read_with_more t bs ~off ~len more in
+    (match more with
+     | Complete ->
+       t.closed <- true
+     | Incomplete -> ());
     consumed
 
   let force_close t =

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -103,7 +103,7 @@ let read_eof t bs ~off ~len =
 let yield_reader t f =
   match t.state with
   | Handshake handshake -> Server_handshake.yield_reader handshake f
-  | Websocket _ -> assert false
+  | Websocket websocket -> Websocket_connection.yield_reader websocket f
 
 let next_write_operation t =
   match t.state with

--- a/lib_test/test_httpun_ws.ml
+++ b/lib_test/test_httpun_ws.ml
@@ -11,11 +11,22 @@ module Websocket = struct
   module Parser = struct
     open Httpun_ws__
 
-    let parse_frame serialized_frame =
+    let parse_frame ~handler serialized_frame =
       let parser =
         let open Angstrom in
-        (Parse.frame ~buf:Bigstringaf.empty) >>= fun frame ->
-          lift (fun () -> frame) (Parse.payload_parser frame)
+        Parse.frame >>= fun frame ->
+          let { Parse.payload_length; _ } = frame in
+          let payload =
+            match payload_length with
+            | 0 -> Payload.create_empty ~on_payload_eof:(fun () -> ())
+            | _ ->
+              Payload.create (Bigstringaf.create 0x100)
+                ~when_ready_to_read:(Optional_thunk.some (fun () -> ()))
+                ~on_payload_eof:(fun () -> ())
+          in
+          let payload_parser = Parse.payload_parser frame payload in
+          handler frame payload;
+          payload_parser
       in
       match Angstrom.parse_string ~consume:All parser serialized_frame with
       | Ok frame -> frame
@@ -35,45 +46,67 @@ module Websocket = struct
       Faraday.serialize_to_string f
 
     let test_parsing_ping_frame () =
-      let frame = parse_frame "\137\128\000\000\046\216" in
-      Alcotest.check Testable.opcode "opcode" `Ping frame.opcode;
-      Alcotest.(check (option int32)) "mask" (Some 11992l) frame.mask;
-      Alcotest.(check int) "payload_length" 0 frame.payload_length
+      let parsed = ref false in
+      parse_frame "\137\128\000\000\046\216" ~handler:(fun frame _payload ->
+        parsed := true;
+        Alcotest.check Testable.opcode "opcode" `Ping frame.opcode;
+        Alcotest.(check (option int32)) "mask" (Some 11992l) frame.mask;
+        Alcotest.(check int) "payload_length" 0 frame.payload_length);
+      Alcotest.(check bool) "parsed" true !parsed
 
     let test_parsing_close_frame () =
-      let frame = parse_frame "\136\000" in
-      Alcotest.check Testable.opcode "opcode" `Connection_close frame.opcode;
-      Alcotest.(check int) "payload_length" 0 frame.payload_length;
-      Alcotest.(check bool) "is_fin" true frame.is_fin
+      let parsed = ref false in
+      parse_frame "\136\000" ~handler:(fun frame _payload ->
+        parsed := true;
+        Alcotest.check Testable.opcode "opcode" `Connection_close frame.opcode;
+        Alcotest.(check int) "payload_length" 0 frame.payload_length;
+        Alcotest.(check bool) "is_fin" true frame.is_fin);
+      Alcotest.(check bool) "parsed" true !parsed
 
-    let read_payload frame =
+    let read_payload payload =
       let rev_payload_chunks = ref [] in
-      let payload =  frame.Parse.payload in
       Payload.schedule_read payload
         ~on_eof:ignore
         ~on_read:(fun bs ~off ~len ->
-        rev_payload_chunks := Bigstringaf.substring bs ~off ~len :: !rev_payload_chunks
+          rev_payload_chunks :=
+            Bigstringaf.substring bs ~off ~len :: !rev_payload_chunks
       );
       !rev_payload_chunks
 
     let test_parsing_text_frame () =
-      let frame = parse_frame "\129\139\086\057\046\216\103\011\029\236\099\015\025\224\111\009\036" in
-      Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
-      Alcotest.(check (option int32)) "mask" (Some 1446588120l) frame.mask;
-      Alcotest.(check int) "payload_length" 11 frame.payload_length;
-      let rev_payload_chunks = read_payload frame in
-      Alcotest.(check bool) "is_fin" true frame.is_fin;
+      let parsed = ref false in
+      let payload = ref None in
+      parse_frame
+        "\129\139\086\057\046\216\103\011\029\236\099\015\025\224\111\009\036"
+        ~handler:(fun frame pload ->
+          parsed := true;
+          Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
+          Alcotest.(check (option int32)) "mask" (Some 1446588120l) frame.mask;
+          Alcotest.(check int) "payload_length" 11 frame.payload_length;
+          Alcotest.(check bool) "is_fin" true frame.is_fin;
+          payload := Some pload;
+        );
+      Alcotest.(check bool) "parsed" true !parsed;
+      let rev_payload_chunks = read_payload (Option.get !payload) in
       Alcotest.(check (list string)) "payload" ["1234567890\n"] rev_payload_chunks
 
 
     let test_parsing_fin_bit () =
-     let frame = parse_frame (serialize_frame ~is_fin:false "hello") in
-      Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
-      Alcotest.(check bool) "is_fin" false frame.is_fin;
-     let frame = parse_frame (serialize_frame ~is_fin:true "hello") in
-      Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
-      Alcotest.(check bool) "is_fin" true frame.is_fin;
-      let rev_payload_chunks = read_payload frame in
+      let parsed = ref false in
+      parse_frame (serialize_frame ~is_fin:false "hello") ~handler:(fun frame _payload ->
+        parsed := true;
+        Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
+        Alcotest.(check bool) "is_fin" false frame.is_fin);
+      Alcotest.(check bool) "parsed" true !parsed;
+      parsed := false;
+      let payload = ref None in
+      parse_frame (serialize_frame ~is_fin:true "hello") ~handler:(fun frame pload ->
+        parsed := true;
+        Alcotest.check Testable.opcode "opcode" `Text frame.opcode;
+        Alcotest.(check bool) "is_fin" true frame.is_fin;
+        payload := Some pload);
+      Alcotest.(check bool) "parsed" true !parsed;
+      let rev_payload_chunks = read_payload (Option.get !payload) in
       Alcotest.(check (list string)) "payload" ["hello"] rev_payload_chunks
 
     let test_parsing_multiple_frames () =

--- a/lib_test/test_httpun_ws.ml
+++ b/lib_test/test_httpun_ws.ml
@@ -18,11 +18,10 @@ module Websocket = struct
           let { Parse.payload_length; _ } = frame in
           let payload =
             match payload_length with
-            | 0 -> Payload.create_empty ~on_payload_eof:(fun () -> ())
+            | 0 -> Payload.create_empty ()
             | _ ->
               Payload.create (Bigstringaf.create 0x100)
                 ~when_ready_to_read:(Optional_thunk.some (fun () -> ()))
-                ~on_payload_eof:(fun () -> ())
           in
           let payload_parser = Parse.payload_parser frame payload in
           handler frame payload;


### PR DESCRIPTION
sort of a fix towards #34 

yields the reader when reads aren't scheduled to provide backpressure, similar to https://github.com/anmonteiro/httpun/pull/59