### PR TITLE
Parse payloads with more than 2 frames in them.

### DIFF
--- a/lib/websocket_connection.ml
+++ b/lib/websocket_connection.ml
@@ -88,10 +88,10 @@ let rec _next_read_operation t =
         (* we just don't advance the request queue in the case of a parser
           error. *)
         op
-      | `Read as op ->
+      | `Read ->
         (* Keep reading when in a "partial" state (`Read). *)
         advance_frame_queue t;
-        op
+        _next_read_operation t
       | `Close ->
         advance_frame_queue t;
         _next_read_operation t))

--- a/lib_test/test_httpun_ws.ml
+++ b/lib_test/test_httpun_ws.ml
@@ -111,7 +111,7 @@ module Websocket = struct
       let rev_payload_chunks = read_payload (Option.get !payload) in
       Alcotest.(check (list string)) "payload" [ "hello" ] rev_payload_chunks
 
-    let test_parsing_multiple_frames () =
+    let test_parsing_multiple_frames n () =
       let frames_parsed = ref 0 in
       let websocket_handler wsd =
         let frame ~opcode ~is_fin:_ ~len:_ payload =
@@ -138,20 +138,21 @@ module Websocket = struct
       in
       let t = Server_connection.create_websocket websocket_handler in
       let frame = serialize_frame ~is_fin:false "hello" in
-      let frames = frame ^ frame in
+      let frames = List.init n (fun _ -> frame) |> String.concat "" in
       let len = String.length frames in
       let bs = Bigstringaf.of_string ~off:0 ~len frames in
       let read = Server_connection.read t bs ~off:0 ~len in
       ignore @@ Server_connection.next_read_operation t;
       Alcotest.(check int) "Reads both frames" len read;
-      Alcotest.(check int) "Both frames parsed and handled" 2 !frames_parsed
+      Alcotest.(check int) "Frames parsed and handled" n !frames_parsed
 
     let tests =
       [ "parsing ping frame", `Quick, test_parsing_ping_frame
       ; "parsing close frame", `Quick, test_parsing_close_frame
       ; "parsing text frame", `Quick, test_parsing_text_frame
       ; "parsing fin bit", `Quick, test_parsing_fin_bit
-      ; "parse 2 frames in a payload", `Quick, test_parsing_multiple_frames
+      ; "parse 2 frames in a payload", `Quick, (test_parsing_multiple_frames 2)
+      ; "parse 3 frames in a payload", `Quick, (test_parsing_multiple_frames 3)
       ]
   end
 


### PR DESCRIPTION
Frames were left in the buffer if more than 2 are received per payload.
That's the fix and a test case. It reproduces the bug in the original impl.